### PR TITLE
solve the 'gbk' error in window system

### DIFF
--- a/workflow/financial-report-knowledge-factory/financial_report_knowledge_factory/extract.py
+++ b/workflow/financial-report-knowledge-factory/financial_report_knowledge_factory/extract.py
@@ -22,7 +22,7 @@ class FinTableProcessor:
 
     def read_file(self):
         """Read file and store data in self.all_data."""
-        with open(self.txt_path, "r") as file:
+        with open(self.txt_path, "r", encoding='utf-8') as file:
             for line in file:
                 data = eval(line)
                 print(data)


### PR DESCRIPTION
In window system, uploading report will meet this error: ‘gbk’code can't decode byte oxac：illegal multibyte sequence.